### PR TITLE
Change dwFrameInterval to 333,333

### DIFF
--- a/multi-gadget.sh
+++ b/multi-gadget.sh
@@ -26,7 +26,7 @@ ln -s /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/header/h /sys
 
 mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p
 cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwFrameInterval
-5000000
+333333
 EOF
 cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wWidth
 1920


### PR DESCRIPTION
This makes the FPS figure to be reported correctly to 30 to programs
that rely on the figure to determine the framerate.